### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,4 +1,6 @@
 name: Test and Release
+permissions:
+  contents: read
 
 # Run this job on all pushes and pull requests
 # as well as tags with a semantic version


### PR DESCRIPTION
Potential fix for [https://github.com/NCIceWolf/ioBroker.easee/security/code-scanning/2](https://github.com/NCIceWolf/ioBroker.easee/security/code-scanning/2)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions. Since the workflow primarily involves read-only operations (e.g., checking out code, installing dependencies, and running tests), the `contents: read` permission is sufficient.

The `permissions` block should be added immediately after the `name` field in the workflow file. This ensures that all jobs in the workflow inherit the least privilege permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
