### PR TITLE
Update node-version in test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -31,7 +31,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x, 22.x, 24.x]
+                node-version: [24.x]
 
         steps:
             - name: Checkout code
@@ -63,7 +63,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [20.x, 22.x, 24.x]
+                node-version: [24.x]
                 # node-version: [18.x, 20.x, 22.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
 


### PR DESCRIPTION
Reduced the node versions in the CI workflow to only 24.x.